### PR TITLE
For next

### DIFF
--- a/src/include/maps.h
+++ b/src/include/maps.h
@@ -3,72 +3,70 @@ revised Sept 2015
 
 Government of Canada Map attributes
         C50k  MAP WIDTH = 30 minutes	11633 pixels varies  	NOT USED
-        C50k  MAP HEIGHT = 15 minutes 	8027 pixels varies		NOT USED
-        C50k  SIZE		unknown - not yet downloaded  FIXME
+        C50k  MAP HEIGHT = 15 minutes 	8027 pixels varies	NOT USED
+        C50k  SIZE 	unknown - not yet downloaded  FIXME
 
         Ctopo MAP WIDTH = 30 minutes	4500 pixels fixed
         Ctopo MAP HEIGHT = 15 minutes 	3600 pixels fixed
-        Ctopo SIZE 				630 gigbytes, 13909 maps (du -h;
-ls -l | wc -l)
+        Ctopo SIZE 	630 gigbytes, 13909 maps (du -h; ls -l | wc -l)
 
-        C250k MAP WIDTH = 2 degrees		8707 pixels varies  map to map
+        C250k MAP WIDTH = 2 degrees	8707 pixels varies  map to map
         C250k MAP HEIGHT = 1 degree 	6758 pixels varies somewhat map to map
-        C250K SIZE 				80 gigbytes, 915 maps (du -h; ls
--l | wc -l)
+        C250K SIZE 	80 gigbytes, 915 maps (du -h; ls -l | wc -l)
 
-        CIMW  MAP WIDTH = 6 degrees		4127 pixels varies
+        CIMW  MAP WIDTH = 6 degrees	4127 pixels varies
         CIMW  MAP HEIGHT = 4 degrees	3738 pixels varies
-        CIMW SIZE 				1.7 gigbytes, 78 maps (du -h; ls
--l | wc -l)
+        CIMW SIZE 	1.7 gigbytes, 78 maps (du -h; ls -l | wc -l)
 
 SEE verifytopo.c for more info
 
 
 *********************************************************************
-   Structure for mapset and map files on disk
+Structure for mapset and map files on disk
+------------------------------------------
 1.  There must be 1 mapset located at:  /MAPSPATH/mapset
 2.  There must be 1 mapindex file [sorted] for each record in mapset:
                 == /MAPSPATH/mapset[i].name/mapindex
 
 
-                *** structure of mapset and maps in memory arrays **
-        loaded from /MAPSPATH/mapset
-        PMTmapset
+Structure of mapset and maps in memory arrays for Canada maps
+-------------------------------------------------------------
+PMTmapset       (loaded from /MAPSPATH/mapset on disk)
+
         -----------------------------------------
-        |C50k		| pointer to C50k mapindex	|--------
-        -----------------------------------------		|
-        |C250k		| pointer to C250k mapindex |-------|----
-        -----------------------------------------		|	|
-        |CIMW		| pointer to CIMW mapindex 	|-------|--	|---|
-        -----------------------------------------		|	|
-| |	|	| |	|	| PMTmapindex
-|	|	|
-        loaded from /MAPSPATH/C50k/mapindex				|
-|	|
-        -----------------------------------------		|	|
-| |dddmmddmm key	| map filename to load	|<-------	|	|
-        |----------------------------------------			|
-| |    ... approx 13,909 records ...		|			|
-|
-        -----------------------------------------			|
-| |	| PMTmapindex
-|	| loaded from /MAPSPATH/C250k/mapindex				|
-|
-        -----------------------------------------			|
-| |dddmmddmm key	| map filename to load	|<----------|	|
-        |---------------------------------------- | |    ... approx 13,909
-records ...		|				|
-        ----------------------------------------- |
-                                                                                                                        |
-        PMTmapindex
-| loaded from /MAPSPATH/CIMW/mapindex |
-        ----------------------------------------- | |dddmmddmm key	| map
-filename to load	|<--------------|
+        |C50k		| pointer to C50k mapindex
+        -----------------------------------------
+        |C250k		| pointer to C250k mapindex
+        -----------------------------------------
+        |CIMW		| pointer to CIMW mapindex
+        -----------------------------------------
+
+PMTmapindex(s)
+        C50k	(loaded from /MAPSPATH/C50k/mapindex)
+        -----------------------------------------
+        |dddmmddmm key	| map filename.png to load from disk
         |----------------------------------------
-        |    ... approx 13,909 records ...		|
+        |    ... approx 13,909 records ...
         -----------------------------------------
 
 
+        C250k 	(loaded from /MAPSPATH/C250k/mapindex)
+        -----------------------------------------
+        |dddmmddmm key	| map filename.png to load from disk
+        |----------------------------------------
+        |    ... approx 919 records ...
+        -----------------------------------------
+
+        CIMW	(loaded from /MAPSPATH/CIMW/mapindex)
+        ----------------------------------------- |
+        |dddmmddmm key	| map filename.png to load from disk
+        |----------------------------------------
+        |    ... approx 78 records ...		|
+        -----------------------------------------
+
+NOTE
+THE ABOVE STRUCTURE CAN BE REPLICATED FOR OTHER JURISDICTIONS via mapsets:
+        eg. USA, Europe, Nautical, Aeronautical etc
 
 */
 

--- a/src/include/maps.h
+++ b/src/include/maps.h
@@ -3,70 +3,72 @@ revised Sept 2015
 
 Government of Canada Map attributes
         C50k  MAP WIDTH = 30 minutes	11633 pixels varies  	NOT USED
-        C50k  MAP HEIGHT = 15 minutes 	8027 pixels varies	NOT USED
-        C50k  SIZE 	unknown - not yet downloaded  FIXME
+        C50k  MAP HEIGHT = 15 minutes 	8027 pixels varies		NOT USED
+        C50k  SIZE		unknown - not yet downloaded  FIXME
 
         Ctopo MAP WIDTH = 30 minutes	4500 pixels fixed
         Ctopo MAP HEIGHT = 15 minutes 	3600 pixels fixed
-        Ctopo SIZE 	630 gigbytes, 13909 maps (du -h; ls -l | wc -l)
+        Ctopo SIZE 				630 gigbytes, 13909 maps (du -h;
+ls -l | wc -l)
 
-        C250k MAP WIDTH = 2 degrees	8707 pixels varies  map to map
+        C250k MAP WIDTH = 2 degrees		8707 pixels varies  map to map
         C250k MAP HEIGHT = 1 degree 	6758 pixels varies somewhat map to map
-        C250K SIZE 	80 gigbytes, 915 maps (du -h; ls -l | wc -l)
+        C250K SIZE 				80 gigbytes, 915 maps (du -h; ls
+-l | wc -l)
 
-        CIMW  MAP WIDTH = 6 degrees	4127 pixels varies
+        CIMW  MAP WIDTH = 6 degrees		4127 pixels varies
         CIMW  MAP HEIGHT = 4 degrees	3738 pixels varies
-        CIMW SIZE 	1.7 gigbytes, 78 maps (du -h; ls -l | wc -l)
+        CIMW SIZE 				1.7 gigbytes, 78 maps (du -h; ls
+-l | wc -l)
 
 SEE verifytopo.c for more info
 
 
 *********************************************************************
-Structure for mapset and map files on disk
-------------------------------------------
+   Structure for mapset and map files on disk
 1.  There must be 1 mapset located at:  /MAPSPATH/mapset
 2.  There must be 1 mapindex file [sorted] for each record in mapset:
                 == /MAPSPATH/mapset[i].name/mapindex
 
 
-Structure of mapset and maps in memory arrays for Canada maps
--------------------------------------------------------------
-PMTmapset       (loaded from /MAPSPATH/mapset on disk)
-
+                *** structure of mapset and maps in memory arrays **
+        loaded from /MAPSPATH/mapset
+        PMTmapset
         -----------------------------------------
-        |C50k		| pointer to C50k mapindex
-        -----------------------------------------
-        |C250k		| pointer to C250k mapindex
-        -----------------------------------------
-        |CIMW		| pointer to CIMW mapindex
-        -----------------------------------------
-
-PMTmapindex(s)
-        C50k	(loaded from /MAPSPATH/C50k/mapindex)
-        -----------------------------------------
-        |dddmmddmm key	| map filename.png to load from disk
-        |----------------------------------------
-        |    ... approx 13,909 records ...
-        -----------------------------------------
-
-
-        C250k 	(loaded from /MAPSPATH/C250k/mapindex)
-        -----------------------------------------
-        |dddmmddmm key	| map filename.png to load from disk
-        |----------------------------------------
-        |    ... approx 919 records ...
-        -----------------------------------------
-
-        CIMW	(loaded from /MAPSPATH/CIMW/mapindex)
+        |C50k		| pointer to C50k mapindex	|--------
+        -----------------------------------------		|
+        |C250k		| pointer to C250k mapindex |-------|----
+        -----------------------------------------		|	|
+        |CIMW		| pointer to CIMW mapindex 	|-------|--	|---|
+        -----------------------------------------		|	|
+| |	|	| |	|	| PMTmapindex
+|	|	|
+        loaded from /MAPSPATH/C50k/mapindex				|
+|	|
+        -----------------------------------------		|	|
+| |dddmmddmm key	| map filename to load	|<-------	|	|
+        |----------------------------------------			|
+| |    ... approx 13,909 records ...		|			|
+|
+        -----------------------------------------			|
+| |	| PMTmapindex
+|	| loaded from /MAPSPATH/C250k/mapindex				|
+|
+        -----------------------------------------			|
+| |dddmmddmm key	| map filename to load	|<----------|	|
+        |---------------------------------------- | |    ... approx 13,909
+records ...		|				|
         ----------------------------------------- |
-        |dddmmddmm key	| map filename.png to load from disk
+                                                                                                                        |
+        PMTmapindex
+| loaded from /MAPSPATH/CIMW/mapindex |
+        ----------------------------------------- | |dddmmddmm key	| map
+filename to load	|<--------------|
         |----------------------------------------
-        |    ... approx 78 records ...		|
+        |    ... approx 13,909 records ...		|
         -----------------------------------------
 
-NOTE
-THE ABOVE STRUCTURE CAN BE REPLICATED FOR OTHER JURISDICTIONS via mapsets:
-        eg. USA, Europe, Nautical, Aeronautical etc
+
 
 */
 

--- a/src/ozdisplay/SDL2init.c
+++ b/src/ozdisplay/SDL2init.c
@@ -9,8 +9,6 @@ FIXME  SDL bug #4232 bugzilla Directfb requires hardware accelerator to work
 
 */
 
-//#define DEBUG   //conditional compilation for debugging
-
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <SDL2/SDL_log.h>

--- a/src/ozdisplay/SDL2init.c
+++ b/src/ozdisplay/SDL2init.c
@@ -9,6 +9,8 @@ FIXME  SDL bug #4232 bugzilla Directfb requires hardware accelerator to work
 
 */
 
+//#define DEBUG   //conditional compilation for debugging
+
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <SDL2/SDL_log.h>

--- a/src/ozdisplay/SDL2misc.c
+++ b/src/ozdisplay/SDL2misc.c
@@ -1,5 +1,7 @@
 /***********   SDL2misc.c  ******************/
 
+//#define DEBUG
+
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <math.h>
@@ -43,7 +45,23 @@ process...
 
 */
 
-/*** load spritesheet from file ***/
+#ifdef DEBUG
+SDL_Surface *getmap(int mapflags) {
+  SDL_Surface *map;
+
+  // Load image at specified path
+  if (mapflags == 0)
+    map = IMG_Load("031e01_1_0.tif");
+  else
+    map = IMG_Load("31e.png");
+
+  if (map == NULL)
+    printf("Unable to load image! SDL_image Error: %s\n", SDL_GetError());
+
+  return (map);
+}
+#endif
+
 /* FIXME memory leak!!! sprite never gets SDL_FreeSurface( sprite ); */
 SDL_Surface *getsprite(char *filename) {
   SDL_Surface *sprite;
@@ -59,9 +77,7 @@ SDL_Surface *getsprite(char *filename) {
 
 /*****************   initsprite ***************************
  * requires square sprites layed out length-wise in spritesheet
- * can be any size (pixels) so long as it is square
- * number of animations within sprite computed via sprite width/height
- * returns number of animations. Completes array of SDL_Rects for extraction
+ * returns number of sprites. Completes array of SDL_Rects for extraction
  */
 int initsprite(SDL_Surface *spritesheet, SDL_Rect *sprite) {
   int spritecount, i;

--- a/src/ozdisplay/SDL2misc.c
+++ b/src/ozdisplay/SDL2misc.c
@@ -1,7 +1,5 @@
 /***********   SDL2misc.c  ******************/
 
-//#define DEBUG
-
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <math.h>
@@ -45,23 +43,7 @@ process...
 
 */
 
-#ifdef DEBUG
-SDL_Surface *getmap(int mapflags) {
-  SDL_Surface *map;
-
-  // Load image at specified path
-  if (mapflags == 0)
-    map = IMG_Load("031e01_1_0.tif");
-  else
-    map = IMG_Load("31e.png");
-
-  if (map == NULL)
-    printf("Unable to load image! SDL_image Error: %s\n", SDL_GetError());
-
-  return (map);
-}
-#endif
-
+/*** load spritesheet from file ***/
 /* FIXME memory leak!!! sprite never gets SDL_FreeSurface( sprite ); */
 SDL_Surface *getsprite(char *filename) {
   SDL_Surface *sprite;
@@ -77,7 +59,9 @@ SDL_Surface *getsprite(char *filename) {
 
 /*****************   initsprite ***************************
  * requires square sprites layed out length-wise in spritesheet
- * returns number of sprites. Completes array of SDL_Rects for extraction
+ * can be any size (pixels) so long as it is square
+ * number of animations within sprite computed via sprite width/height
+ * returns number of animations. Completes array of SDL_Rects for extraction
  */
 int initsprite(SDL_Surface *spritesheet, SDL_Rect *sprite) {
   int spritecount, i;

--- a/src/ozdisplay/SDL2misc.c
+++ b/src/ozdisplay/SDL2misc.c
@@ -1,7 +1,5 @@
 /***********   SDL2misc.c  ******************/
 
-//#define DEBUG
-
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <math.h>
@@ -44,23 +42,6 @@ process...
         - get pixel center of new map ....etyc
 
 */
-
-#ifdef DEBUG
-SDL_Surface *getmap(int mapflags) {
-  SDL_Surface *map;
-
-  // Load image at specified path
-  if (mapflags == 0)
-    map = IMG_Load("031e01_1_0.tif");
-  else
-    map = IMG_Load("31e.png");
-
-  if (map == NULL)
-    printf("Unable to load image! SDL_image Error: %s\n", SDL_GetError());
-
-  return (map);
-}
-#endif
 
 /* FIXME memory leak!!! sprite never gets SDL_FreeSurface( sprite ); */
 SDL_Surface *getsprite(char *filename) {

--- a/src/ozdisplay/displaymap.c
+++ b/src/ozdisplay/displaymap.c
@@ -30,8 +30,6 @@ END FIXME
 #include <limits.h>
 #include <stdio.h>
 
-#define DEBUG
-
 #define SCREEN_WIDTH 500
 #define SCREEN_HEIGHT 500
 #define MAPSCALEDELTA 0.50

--- a/src/ozdisplay/displaymap.c
+++ b/src/ozdisplay/displaymap.c
@@ -144,8 +144,6 @@ main() {
   SDL_Point nowest = {SCREEN_WIDTH / 5, SCREEN_HEIGHT / 5};
   SDL_Point noeast = {400, SCREEN_HEIGHT / 5};
 
-  SDL_RendererFlip flip = SDL_FLIP_NONE;
-
   int x = 0, y = 0, // coordinates for inMotion movement
       xnew = 0, ynew = 0, xdelta = 0, ydelta = 0;
   /* flags */
@@ -173,8 +171,6 @@ main() {
   Uint8 alphabutton;          // alpha fading for buttons
   char filename[PATH_MAX];
 
-  Uint64 gps;
-  int mymapindex; /* %100 = mapsetindex, /100 = mapindex within mapset*/
 
   /******************** Step 1 game initialize **************************/
 

--- a/src/ozdisplay/displaymap.c
+++ b/src/ozdisplay/displaymap.c
@@ -30,6 +30,8 @@ END FIXME
 #include <limits.h>
 #include <stdio.h>
 
+#define DEBUG
+
 #define SCREEN_WIDTH 500
 #define SCREEN_HEIGHT 500
 #define MAPSCALEDELTA 0.50

--- a/src/ozdisplay/displaymap.c
+++ b/src/ozdisplay/displaymap.c
@@ -74,6 +74,7 @@ int scalepoint(SDL_Rect *, SDL_Point *, SDL_Point *);
 PMTmapset *initmaps(void);
 SDL_Surface *getmap(int, PMTmapset *, SDL_Rect *);
 SDL_Point *placegps(SDL_Surface *mymap);
+void closemaps(PMTmapset *);
 
 char *datapath = NULL;
 

--- a/src/ozdisplay/displaymap.c
+++ b/src/ozdisplay/displaymap.c
@@ -112,7 +112,7 @@ static char *find_datadir() {
   return NULL;
 }
 
-main() {
+int main() {
   SDL_Surface *mymap; /*mymap= active map on screen */
   SDL_Surface *spritesheet;
   SDL_Surface *buttonsheet;

--- a/src/ozdisplay/displaymap.c
+++ b/src/ozdisplay/displaymap.c
@@ -30,8 +30,6 @@ END FIXME
 #include <limits.h>
 #include <stdio.h>
 
-#define DEBUG
-
 #define SCREEN_WIDTH 500
 #define SCREEN_HEIGHT 500
 #define MAPSCALEDELTA 0.50
@@ -173,7 +171,6 @@ int main() {
   int centerFmsecs, mapmsecs; // timers in milliseconds
   Uint8 alphabutton;          // alpha fading for buttons
   char filename[PATH_MAX];
-
 
   /******************** Step 1 game initialize **************************/
 

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -60,16 +60,6 @@ int keysubtract(int, int);
 int gpstogpskey(uint64_t);
 int inthemap(int, PMTmapindex *);
 
-//  #define DEBUG
-#ifdef DEBUG
-
-#include "SDL2/SDL2_gfxPrimitives.h"
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_image.h>
-#define SCREEN_WIDTH 500
-#define SCREEN_HEIGHT 500
-
-#endif
 
 /**********************   getmap ****************************************
         ALL map movement is handled in this routine.

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -1,22 +1,19 @@
 /*    mapmanager.c
         - compile with  gcc -g mapmanager.c initmaps.c mapmisc.c
    ../ozdisplay/SDL2init.c initgps.c -o ../../mapmanager -lSDL2 -lSDL2_image -lm
-
-
 */
 /* written Peter Thompson Sept 2015
    Designed to simplify the main game loop calls to 3 simple calls
 
-PMTmapset* 		initmaps();
+PMTmapset* 	initmaps();
 SDL_Surface* 	getmap(int, PMTmapset*);
-SDL_Point*		placegps(SDL_Surface*);
+SDL_Point*	placegps(SDL_Surface*);
 
 
-****************   3 key pointers are maintained by mapmanager.c
-**************** PMTmapset* 		mapsetNow; 			points
-to current mapset in use PMTmapindex* 	mapindexNow;		points to
-current map in use SDL_Surface*	mapNow;				current map on
-display
+*****   3 key pointers are maintained by mapmanager.c********
+PMTmapset* 	mapsetNow; 	points to current mapset in use
+PMTmapindex* 	mapindexNow;	points to current map in use 
+SDL_Surface*	mapNow;		current map on display
 
 
 */
@@ -31,20 +28,18 @@ display
 #define TRUE 1
 #define FALSE 0
 
-/************ static Now variables shared within this source file ***********/
+/************ static Now variables shared within this source file ********/
 /*	- there is no way around these 3 amigos + = semi-global variables
  */
 
-// static PMTmapset* 		mapsetNow; 		/* points to current
-// mapset in use */
-static PMTmapindex *mapindexNow; /* points to current map in use */
-// static SDL_Surface*		mapNow;			/* current map on
-// display
-// */
-static int firsttime = TRUE; /* gps initialization flag */
+// static PMTmapset 	*mapsetNow;  /* current mapset DUPLICATE FIXME */
+static PMTmapindex 	*mapindexNow; 	/* current map in use */
+// static SDL_Surface	*mapNow; /*current map on display DUPLICATE FIXME*/
+
+static int firsttime = TRUE; 		/* gps initialization flag */
 static PMTmapindex *homemapindex;
 
-/******************************************************************************/
+/*************************************************************************/
 
 /* function prototypes*/
 SDL_Point *gpstopixel(PMTmapindex *, SDL_Surface *, uint64_t);

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -60,7 +60,6 @@ int keysubtract(int, int);
 int gpstogpskey(uint64_t);
 int inthemap(int, PMTmapindex *);
 
-
 /**********************   getmap ****************************************
         ALL map movement is handled in this routine.
         3 Static variables are used to know where we are ALL times
@@ -249,8 +248,8 @@ SDL_Surface *getmap(int mapflags,      /* instructions on which map to get */
       camera->y = 0;
       return (mapNow);
     }
-  } else 
-     return (mapNow);  /* should never reach here */
+  } else
+    return (mapNow); /* should never reach here */
 }
 
 /********************** SDL_Point placegps(SDL_Surface) *******************/

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -1,19 +1,22 @@
 /*    mapmanager.c
         - compile with  gcc -g mapmanager.c initmaps.c mapmisc.c
    ../ozdisplay/SDL2init.c initgps.c -o ../../mapmanager -lSDL2 -lSDL2_image -lm
+
+
 */
 /* written Peter Thompson Sept 2015
    Designed to simplify the main game loop calls to 3 simple calls
 
-PMTmapset* 	initmaps();
+PMTmapset* 		initmaps();
 SDL_Surface* 	getmap(int, PMTmapset*);
-SDL_Point*	placegps(SDL_Surface*);
+SDL_Point*		placegps(SDL_Surface*);
 
 
-*****   3 key pointers are maintained by mapmanager.c********
-PMTmapset* 	mapsetNow; 	points to current mapset in use
-PMTmapindex* 	mapindexNow;	points to current map in use 
-SDL_Surface*	mapNow;		current map on display
+****************   3 key pointers are maintained by mapmanager.c
+**************** PMTmapset* 		mapsetNow; 			points
+to current mapset in use PMTmapindex* 	mapindexNow;		points to
+current map in use SDL_Surface*	mapNow;				current map on
+display
 
 
 */
@@ -28,18 +31,20 @@ SDL_Surface*	mapNow;		current map on display
 #define TRUE 1
 #define FALSE 0
 
-/************ static Now variables shared within this source file ********/
+/************ static Now variables shared within this source file ***********/
 /*	- there is no way around these 3 amigos + = semi-global variables
  */
 
-// static PMTmapset 	*mapsetNow;  /* current mapset DUPLICATE FIXME */
-static PMTmapindex 	*mapindexNow; 	/* current map in use */
-// static SDL_Surface	*mapNow; /*current map on display DUPLICATE FIXME*/
-
-static int firsttime = TRUE; 		/* gps initialization flag */
+// static PMTmapset* 		mapsetNow; 		/* points to current
+// mapset in use */
+static PMTmapindex *mapindexNow; /* points to current map in use */
+// static SDL_Surface*		mapNow;			/* current map on
+// display
+// */
+static int firsttime = TRUE; /* gps initialization flag */
 static PMTmapindex *homemapindex;
 
-/*************************************************************************/
+/******************************************************************************/
 
 /* function prototypes*/
 SDL_Point *gpstopixel(PMTmapindex *, SDL_Surface *, uint64_t);

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -12,7 +12,7 @@ SDL_Point*	placegps(SDL_Surface*);
 
 *****   3 key pointers are maintained by mapmanager.c********
 PMTmapset* 	mapsetNow; 	points to current mapset in use
-PMTmapindex* 	mapindexNow;	points to current map in use
+PMTmapindex* 	mapindexNow;	points to current map in use 
 SDL_Surface*	mapNow;		current map on display
 
 
@@ -33,10 +33,10 @@ SDL_Surface*	mapNow;		current map on display
  */
 
 // static PMTmapset 	*mapsetNow;  /* current mapset DUPLICATE FIXME */
-static PMTmapindex *mapindexNow; /* current map in use */
+static PMTmapindex 	*mapindexNow; 	/* current map in use */
 // static SDL_Surface	*mapNow; /*current map on display DUPLICATE FIXME*/
 
-static int firsttime = TRUE; /* gps initialization flag */
+static int firsttime = TRUE; 		/* gps initialization flag */
 static PMTmapindex *homemapindex;
 
 /*************************************************************************/
@@ -54,6 +54,7 @@ int keyadd(int, int);
 int keysubtract(int, int);
 int gpstogpskey(uint64_t);
 int inthemap(int, PMTmapindex *);
+
 
 /**********************   getmap ****************************************
         ALL map movement is handled in this routine.
@@ -243,8 +244,8 @@ SDL_Surface *getmap(int mapflags,      /* instructions on which map to get */
       camera->y = 0;
       return (mapNow);
     }
-  } else
-    return (mapNow); /* should never reach here */
+  } else 
+     return (mapNow);  /* should never reach here */
 }
 
 /********************** SDL_Point placegps(SDL_Surface) *******************/

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -55,6 +55,10 @@ uint64_t pixeltogps(PMTmapindex *, SDL_Surface *, SDL_Rect *);
 PMTmapindex *findmapkey(int, PMTmapset *, PMTmapindex *);
 PMTmapindex *findgpsmap(uint64_t, PMTmapset *);
 SDL_Surface *loadmap(PMTmapset *, PMTmapindex *, SDL_Surface *);
+int keyadd(int, int);
+int keysubtract(int, int);
+int gpstogpskey(uint64_t);
+int inthemap(int, PMTmapindex *);
 
 //  #define DEBUG
 #ifdef DEBUG

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -248,7 +248,8 @@ SDL_Surface *getmap(int mapflags,      /* instructions on which map to get */
       camera->y = 0;
       return (mapNow);
     }
-  }
+  } else 
+     return (mapNow);  /* should never reach here */
 }
 
 /********************** SDL_Point placegps(SDL_Surface) *******************/

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -98,7 +98,8 @@ SDL_Surface *getmap(int mapflags,      /* instructions on which map to get */
       if ((mapindexTemp = findgpsmap(gps, mapsetNow)) == NULL) { // not found
         mapset++;
         if (bookend == 9999) {
-          printf(" no map found for gps (dddmmssddmmss)=%llu \n", gps);
+          printf(" no map found for gps (dddmmssddmmss)=%llu \n",
+                 (long long)gps);
           exit(0);
         }
       } else { // found

--- a/src/ozmaps/mapmanager.c
+++ b/src/ozmaps/mapmanager.c
@@ -12,7 +12,7 @@ SDL_Point*	placegps(SDL_Surface*);
 
 *****   3 key pointers are maintained by mapmanager.c********
 PMTmapset* 	mapsetNow; 	points to current mapset in use
-PMTmapindex* 	mapindexNow;	points to current map in use 
+PMTmapindex* 	mapindexNow;	points to current map in use
 SDL_Surface*	mapNow;		current map on display
 
 
@@ -33,10 +33,10 @@ SDL_Surface*	mapNow;		current map on display
  */
 
 // static PMTmapset 	*mapsetNow;  /* current mapset DUPLICATE FIXME */
-static PMTmapindex 	*mapindexNow; 	/* current map in use */
+static PMTmapindex *mapindexNow; /* current map in use */
 // static SDL_Surface	*mapNow; /*current map on display DUPLICATE FIXME*/
 
-static int firsttime = TRUE; 		/* gps initialization flag */
+static int firsttime = TRUE; /* gps initialization flag */
 static PMTmapindex *homemapindex;
 
 /*************************************************************************/
@@ -54,7 +54,6 @@ int keyadd(int, int);
 int keysubtract(int, int);
 int gpstogpskey(uint64_t);
 int inthemap(int, PMTmapindex *);
-
 
 /**********************   getmap ****************************************
         ALL map movement is handled in this routine.
@@ -243,8 +242,8 @@ SDL_Surface *getmap(int mapflags,      /* instructions on which map to get */
       camera->y = 0;
       return (mapNow);
     }
-  } else 
-     return (mapNow);  /* should never reach here */
+  } else
+    return (mapNow); /* should never reach here */
 }
 
 /********************** SDL_Point placegps(SDL_Surface) *******************/

--- a/src/ozmaps/mapmisc.c
+++ b/src/ozmaps/mapmisc.c
@@ -4,8 +4,6 @@
 
 */
 
-// #define DEBUG
-
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <limits.h>
@@ -109,10 +107,6 @@ int gpstogpskey(uint64_t gps) {
     latmm++;
   gpskey = longdd * 1000000 + longmm * 10000 + latdd * 100 + latmm;
 
-#ifdef DEBUG
-  printf("gps = %lu\n", gps);
-  printf("gpskey(dddmmddmm) = %d\n", gpskey);
-#endif
 
   return (gpskey);
 }

--- a/src/ozmaps/mapmisc.c
+++ b/src/ozmaps/mapmisc.c
@@ -107,7 +107,6 @@ int gpstogpskey(uint64_t gps) {
     latmm++;
   gpskey = longdd * 1000000 + longmm * 10000 + latdd * 100 + latmm;
 
-
   return (gpskey);
 }
 

--- a/src/ozmaps/mapmisc.c
+++ b/src/ozmaps/mapmisc.c
@@ -1,9 +1,7 @@
 /*********    mapmisc.c   ********************
 * miscellaneous functions to  convert longlat to pixel and back
  gps longlat format=dddmmssddmmss::  mapkey longlat format=dddmmddmm
- FIXME switch to latlong for searching AND research using double on BBB
-  since NOAA=double degrees, GPS:GPGGA=double minutes  AND look for format converter
-  on github.   FIXME 
+
 */
 
 #include <SDL2/SDL.h>

--- a/src/ozmaps/mapmisc.c
+++ b/src/ozmaps/mapmisc.c
@@ -1,7 +1,9 @@
 /*********    mapmisc.c   ********************
 * miscellaneous functions to  convert longlat to pixel and back
  gps longlat format=dddmmssddmmss::  mapkey longlat format=dddmmddmm
-
+ FIXME switch to latlong for searching AND research using double on BBB
+  since NOAA=double degrees, GPS:GPGGA=double minutes  AND look for format converter
+  on github.   FIXME 
 */
 
 #include <SDL2/SDL.h>


### PR DESCRIPTION
Update of ozmaps/mapmanager.c - 4 commits:
ozmaps: mapmanager.c: add 4 function prototypes to fix compiler warnings
ozmaps: Remove DEBUG define from mapmanager.c
ozmaps: mapmanager.c end getmap() function properly to remove compiler warnings
ozmaps: mapmanager.c make comments readable where clang-format made unreadable

This fixes mapmanager.c except for 1 compiler error which will be fixed in a later commit.

UPDATE -  Feb 8: 4pm
Another 9 commits were added here to:
 - finish removing DEBUG define
 - removes all compiler errors!!
 - add/change some comments
 - cleanup long descriptive comments which were muddled by clang-format

TODO 
3 new branches (I hope) to keep separate from the above commits:
 - dieface  with 2 commits to prepare for integration of dieface/viewsensor.c into hikingGPS  
       The daemons will remain separate of course. 
 - BBB with 2-3 commits to distinguish beaglebone black compiles via -D BBB
 - SDL2init with 3 commits to 
      replace a deprecated SDL2 command, 
      print SDL2 version,
      move find_datadir() from displaymap.c to SDL2init.c  