### PR TITLE
ozdisplay: Remove DEBUG define from displaymap.c, SDL2init.c SDL2misc.c

### DIFF
--- a/src/ozdisplay/SDL2init.c
+++ b/src/ozdisplay/SDL2init.c
@@ -9,8 +9,6 @@ FIXME  SDL bug #4232 bugzilla Directfb requires hardware accelerator to work
 
 */
 
-//#define DEBUG   //conditional compilation for debugging
-
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <SDL2/SDL_log.h>

--- a/src/ozdisplay/SDL2misc.c
+++ b/src/ozdisplay/SDL2misc.c
@@ -1,7 +1,5 @@
 /***********   SDL2misc.c  ******************/
 
-//#define DEBUG
-
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_image.h>
 #include <math.h>
@@ -44,23 +42,6 @@ process...
         - get pixel center of new map ....etyc
 
 */
-
-#ifdef DEBUG
-SDL_Surface *getmap(int mapflags) {
-  SDL_Surface *map;
-
-  // Load image at specified path
-  if (mapflags == 0)
-    map = IMG_Load("031e01_1_0.tif");
-  else
-    map = IMG_Load("31e.png");
-
-  if (map == NULL)
-    printf("Unable to load image! SDL_image Error: %s\n", SDL_GetError());
-
-  return (map);
-}
-#endif
 
 /* FIXME memory leak!!! sprite never gets SDL_FreeSurface( sprite ); */
 SDL_Surface *getsprite(char *filename) {

--- a/src/ozdisplay/displaymap.c
+++ b/src/ozdisplay/displaymap.c
@@ -30,8 +30,6 @@ END FIXME
 #include <limits.h>
 #include <stdio.h>
 
-#define DEBUG
-
 #define SCREEN_WIDTH 500
 #define SCREEN_HEIGHT 500
 #define MAPSCALEDELTA 0.50


### PR DESCRIPTION
The #define DEBUG was used for debugging.  Now deprecated.
A ifdef DEBUG codeblock removed as well from SDL2misc.
This is a repeat of commit ee777de which was not merged.
Other DEBUG statements removed in earlier commits.

Signed-off-by: Peter Macleod Thompson <peter.macleod.thompson@gmail.com>